### PR TITLE
Adds Cache buster

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "babel-loader": "^9.1.3",
         "css-loader": "^7.1.2",
         "html-webpack-plugin": "^5.6.0",
+        "mini-css-extract-plugin": "^2.9.1",
         "sass": "^1.77.8",
         "sass-loader": "^16.0.1",
         "style-loader": "^4.0.0",
@@ -7736,6 +7737,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mini-css-extract-plugin": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.4.tgz",
+      "integrity": "sha512-ZWYT7ln73Hptxqxk2DxPU9MmapXRhxkJD6tkSR04dnQxm8BGu2hzgKLugK5yySD97u/8yy7Ma7E76k9ZdvtjkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "schema-utils": "^4.0.0",
+        "tapable": "^2.2.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -16116,6 +16138,16 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+    },
+    "mini-css-extract-plugin": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.4.tgz",
+      "integrity": "sha512-ZWYT7ln73Hptxqxk2DxPU9MmapXRhxkJD6tkSR04dnQxm8BGu2hzgKLugK5yySD97u/8yy7Ma7E76k9ZdvtjkQ==",
+      "dev": true,
+      "requires": {
+        "schema-utils": "^4.0.0",
+        "tapable": "^2.2.1"
+      }
     },
     "minimalistic-assert": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-loader": "^9.1.3",
     "css-loader": "^7.1.2",
     "html-webpack-plugin": "^5.6.0",
+    "mini-css-extract-plugin": "^2.9.1",
     "sass": "^1.77.8",
     "sass-loader": "^16.0.1",
     "style-loader": "^4.0.0",


### PR DESCRIPTION
## Prompt
I’m deploying an web app to app engine. I use webpack. For some reason all copies to stick around and get cached. How do I prevent this from happening?

Here is my webpack.config.js file. Add the required lines, and show me the new package.json